### PR TITLE
Ruby 1.9.2 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ PATH
       activesupport (>= 2.3.0)
       json (>= 1.4.0)
       redis (>= 2.1.0)
-      system_timer (>= 1.0.0)
       time_ext (>= 0.2.8)
 
 GEM
@@ -24,7 +23,6 @@ GEM
     rspec-expectations (2.1.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.1.0)
-    system_timer (1.0)
     time_ext (0.2.8)
       activesupport (>= 2.3.0)
       i18n (>= 0.4.2)
@@ -39,6 +37,5 @@ DEPENDENCIES
   redis (>= 2.1.0)
   redistat!
   rspec (>= 2.1.0)
-  system_timer (>= 1.0.0)
   time_ext (>= 0.2.8)
   yard (>= 0.6.3)

--- a/lib/redistat.rb
+++ b/lib/redistat.rb
@@ -26,6 +26,7 @@ require 'redistat/summary'
 require 'redistat/core_ext/date'
 require 'redistat/core_ext/time'
 require 'redistat/core_ext/fixnum'
+require 'redistat/core_ext/bignum'
 
 module Redistat
   

--- a/lib/redistat/core_ext/bignum.rb
+++ b/lib/redistat/core_ext/bignum.rb
@@ -1,0 +1,8 @@
+class Bignum
+  include Redistat::DateHelper
+  
+  def to_time
+    Time.at(self)
+  end
+  
+end

--- a/lib/redistat/date.rb
+++ b/lib/redistat/date.rb
@@ -22,6 +22,8 @@ module Redistat
         from_string(input)
       elsif input.is_a?(::Fixnum)
         from_integer(input)
+      elsif input.is_a?(::Bignum)
+        from_integer(input)
       end
     end
     

--- a/lib/redistat/finder/date_set.rb
+++ b/lib/redistat/finder/date_set.rb
@@ -42,7 +42,7 @@ module Redistat
         return find_start_year_for(start_date, end_date, lowest_depth) if unit == :year
         index = Date::DEPTHS.index(unit)
         nunit = Date::DEPTHS[(index > 0) ? index-1 : index]
-        if start_date < start_date.round(nunit) || start_date.next(nunit).beginning_of(nunit) > end_date.beginning_of(nunit)
+        if start_date < start_date.beginning_of_closest(nunit) || start_date.next(nunit).beginning_of(nunit) > end_date.beginning_of(nunit)
           add = []
           start_date.beginning_of_each(unit, :include_start => lowest_depth).until(start_date.end_of(nunit)) do |t|
             add << t.to_rs.to_s(unit) if t < end_date.beginning_of(unit)
@@ -59,7 +59,7 @@ module Redistat
         index = Date::DEPTHS.index(unit)
         nunit = Date::DEPTHS[(index > 0) ? index-1 : index]
         has_nunit = end_date.prev(nunit).beginning_of(nunit) >= start_date.beginning_of(nunit)
-        nearest_nunit = end_date.round(nunit)
+        nearest_nunit = end_date.beginning_of_closest(nunit)
         if end_date >= nearest_nunit && has_nunit
           add = []
           end_date.beginning_of(nunit).beginning_of_each(unit, :include_start => true, :include_end => lowest_depth).until(end_date) do |t|

--- a/redistat.gemspec
+++ b/redistat.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport', '>= 2.3.0'
   s.add_runtime_dependency 'json', '>= 1.4.0'
   s.add_runtime_dependency 'redis', '>= 2.1.0'
-  s.add_runtime_dependency 'system_timer', '>= 1.0.0'
   s.add_runtime_dependency 'time_ext', '>= 0.2.8'
   
   s.add_development_dependency 'rspec', '>= 2.1.0'

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -20,7 +20,7 @@ describe Redistat::Event do
     @event.scope.should == @scope
     @event.label.should == @label
     @event.label_hash.should == @label_hash
-    @event.date.to_time.should == @date
+    @event.date.to_time.to_s.should == @date.to_s
     @event.stats.should == @stats
     @event.meta.should == @meta
     @event.options.should == @event.default_options.merge(@options)
@@ -28,10 +28,10 @@ describe Redistat::Event do
 
   it "should allow changing attributes" do
     # date
-    @event.date.to_time.should == @date
+    @event.date.to_time.to_s.should == @date.to_s
     @date = Time.now
     @event.date = @date
-    @event.date.to_time.should == @date
+    @event.date.to_time.to_s.should == @date.to_s
     # label
     @event.label.should == @label
     @event.label_hash.should == @label_hash

--- a/spec/key_spec.rb
+++ b/spec/key_spec.rb
@@ -46,10 +46,10 @@ describe Redistat::Key do
     @key.scope = @scope
     @key.scope.should == @scope
     # date
-    @key.date.to_time.should == @date
+    @key.date.to_time.to_s.should == @date.to_s
     @date = Time.now
     @key.date = @date
-    @key.date.to_time.should == @date
+    @key.date.to_time.to_s.should == @date.to_s
     # label
     @key.label.should == @label
     @key.label_hash == @label_hash


### PR DESCRIPTION
These commits fix problems for 1.9.2 compatibility, but I have not tested them on 1.8.7 in light of my changes. I do not believe any of the changes should break backwards compatibility with the exception of the gemspec dependency on system_timer, which is not required in 1.9.2 and must be omitted to prevent hideous problems when trying to bring in redistat in a Gemfile. Not quite sure how to go about attacking that problem.
